### PR TITLE
Fix 6 mobile bugs: toolbar access, touch transitions, UI affordances

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@
 
             <!-- Left sidebar: controls -->
             <aside id="sidebar-left">
+                <button id="btn-sidebar-close" class="sidebar-close-btn" title="Close">&times;</button>
                 <!-- Presets -->
                 <div class="sidebar-presets">
                     <label class="control-label">Presets</label>

--- a/js/editor.js
+++ b/js/editor.js
@@ -278,11 +278,27 @@ const Editor = (function () {
                         initialPinchZoom = null;
                         pinchCenter = null;
                     } else if (e.touches.length === 1 && isPinching) {
-                        // One finger lifted during pinch, transition to single-touch
+                        // One finger lifted during pinch — transition to single-touch mode
                         isPinching = false;
                         initialPinchDistance = null;
                         initialPinchZoom = null;
                         pinchCenter = null;
+
+                        // Activate single-touch so the remaining finger can use tools
+                        isTouching = true;
+                        const remainingTouch = e.touches[0];
+                        const rect = canvas.getBoundingClientRect();
+                        const point = new paper.Point(
+                            remainingTouch.clientX - rect.left,
+                            remainingTouch.clientY - rect.top
+                        );
+                        touchStartPoint = paper.view.viewToProject(point);
+
+                        // Trigger tool's mouseDown for the remaining finger
+                        const activeTool = paper.tools.find((t) => t === paper.tool);
+                        if (activeTool && activeTool.onMouseDown) {
+                            activeTool.onMouseDown({ point: touchStartPoint });
+                        }
                     }
                 },
                 { passive: false }

--- a/js/script.js
+++ b/js/script.js
@@ -662,8 +662,9 @@
         var colorNames = ['light', 'mid', 'dark'];
         var colorValues = ['#808080', '#404040', '#000000']; // Gray to black
 
-        // Export each layer as separate SVG
-        for (var layer = 0; layer < layerCount; layer++) {
+        // Export each layer as separate SVG with staggered downloads
+        // (mobile browsers block rapid sequential downloads)
+        function exportLayer(layer) {
             var startIdx = layer * groupsPerLayer;
             var endIdx = Math.min(startIdx + groupsPerLayer, lastRenderResult.groups.length);
 
@@ -705,7 +706,17 @@
             paper.project = paper.projects[0];
         }
 
-        alert('Exported ' + layerCount + ' color layers:\n' + colorNames.slice(0, layerCount).join(', '));
+        // Stagger downloads with 500ms delay to avoid mobile browser blocking
+        for (var layer = 0; layer < layerCount; layer++) {
+            (function (l) {
+                setTimeout(function () {
+                    exportLayer(l);
+                    if (l === layerCount - 1) {
+                        alert('Exported ' + layerCount + ' color layers:\n' + colorNames.slice(0, layerCount).join(', '));
+                    }
+                }, l * 500);
+            })(layer);
+        }
     }
 
     function exportGCode() {
@@ -1361,6 +1372,12 @@
         });
 
         overlay.addEventListener('click', function () {
+            sidebar.classList.remove('open');
+            overlay.classList.remove('visible');
+        });
+
+        // Close button inside sidebar (visible at 480px when sidebar is full-width)
+        $('btn-sidebar-close').addEventListener('click', function () {
             sidebar.classList.remove('open');
             overlay.classList.remove('visible');
         });

--- a/styles.css
+++ b/styles.css
@@ -137,11 +137,9 @@ body {
     background: var(--bg-primary);
     overflow: hidden;
     user-select: none;
-    /* Prevent pull-to-refresh and overscroll on mobile */
-    overscroll-behavior: none;
-    -webkit-overflow-scrolling: touch;
     /* Mobile optimizations */
-    overscroll-behavior: none; /* Prevent iOS rubber band effect */
+    overscroll-behavior: none; /* Prevent pull-to-refresh and rubber band effect */
+    -webkit-overflow-scrolling: touch;
     -webkit-tap-highlight-color: transparent; /* Remove iOS tap highlight */
     position: relative;
 }
@@ -1613,6 +1611,25 @@ input[type='color']::-webkit-color-swatch {
     display: none;
 }
 
+/* Close button inside sidebar (for full-width mobile) */
+.sidebar-close-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 260;
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 20px;
+    line-height: 1;
+}
+
 /* === Responsive: hide right sidebar on narrow screens === */
 @media (max-width: 1100px) {
     #sidebar-right {
@@ -1654,6 +1671,16 @@ input[type='color']::-webkit-color-swatch {
         gap: 4px;
     }
     .toolbar-center {
+        display: flex;
+        gap: 2px;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    /* Hide less critical groups on mobile to save space */
+    .toolbar-center .toolbar-separator {
+        display: none;
+    }
+    .toolbar-center .zoom-label {
         display: none;
     }
     .app-title {
@@ -1738,6 +1765,14 @@ input[type='color']::-webkit-color-swatch {
         font-size: 13px;
     }
 
+    /* "Change" button always visible on touch devices */
+    .source-preview .small-btn {
+        opacity: 1;
+        padding: 8px 16px;
+        font-size: 13px;
+        min-height: 44px;
+    }
+
     /* Export buttons compact but still tappable */
     .export-btn {
         padding: 10px 12px;
@@ -1775,6 +1810,18 @@ input[type='color']::-webkit-color-swatch {
     #sidebar-left {
         width: 100vw;
         min-width: 100vw;
+    }
+
+    /* Close button for full-width sidebar (overlay is hidden behind it) */
+    .sidebar-close-btn {
+        display: flex;
+    }
+
+    /* Hide zoom buttons on very small screens — pinch-to-zoom available */
+    #btn-zoom-in,
+    #btn-zoom-out,
+    #btn-zoom-fit {
+        display: none;
     }
 
     /* Larger touch targets on small screens */


### PR DESCRIPTION
- Show toolbar-center on mobile (was display:none) so Select/Pan/Erase, Undo/Redo, and Zoom tools are accessible; hide separators and zoom label to save space; hide zoom buttons at 480px (pinch available)
- Make "Change Image" button always visible on mobile (was hover-only, unreachable on touch devices)
- Fix pinch-to-single-touch transition: lifting one finger during pinch now activates single-touch mode so the remaining finger can use tools
- Add close button to full-width sidebar at 480px where the backdrop overlay is hidden behind the sidebar
- Remove duplicate overscroll-behavior:none declaration
- Stagger multi-color layer SVG downloads with 500ms delays to prevent mobile browsers from blocking sequential programmatic downloads

https://claude.ai/code/session_01Fw1bfjKZeYfsDmrKSQgQkU